### PR TITLE
Use the internal URL for nginx proxy pass

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,12 +5,13 @@ ghost_fetch_dir: /tmp
 ghost_nodejs_pin_priority: 500
 ghost_nodejs_path: /usr/bin/node
 
+ghost_internal_url: http://{{ ghost_config_server.host }}:{{ ghost_config_server.port }}
+
 ghost_nginx_sites:
   ghost:
     - listen {{ ghost_nginx_port }}
     - server_name {{ ghost_config_server.host }}
     - proxy_set_header X-Real-IP $remote_addr
     - proxy_set_header Host $http_host
-    - location / { proxy_pass {{ ghost_config_url }}; }
+    - location / { proxy_pass {{ ghost_internal_url }}; }
     - location ~ ^/ghost/setup { allow {{ ghost_nginx_admin_allowed_cidr }}; deny all; }
-


### PR DESCRIPTION
`ghost_config_url` contains the external URL for the site. It's used in
the ghost config.js to set the site URL.

By default, the value of `ghost_config_url` is set to the internal ghost
URL (i.e. 127.0.0.1:2368). If the user overrides that setting to set it
to the public domain name for the blog (e.g. http://codebeef.com), while
maintaining the value of `ghost_config_server`, then the blog should be
configures with the correct domain name, and the ghost instance should
still be set to bind to 127.0.0.1:2368, with this value set in the
proxy_pass for nginx.

Currently, changing the `ghost_config_url` also changes the proxy_pass
setting. This commit changes that so that the proxy_pass setting comes
from the `ghost_config_server` values.
