### PR TITLE
Changed nodesource.node dependency to SimpliField.node for nodejs 6.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Internal variables, avoid changing:
 Dependencies
 ------------
 
-* [nodesource.node](https://galaxy.ansible.com/list#/roles/1488)
-* [jdauphant.nginx](https://galaxy.ansible.com/list#/roles/466)
+* [SimpliField.node](https://galaxy.ansible.com/SimpliField/node/)
+* [jdauphant.nginx](https://galaxy.ansible.com/jdauphant/nginx/)
 
 These roles can be installed by running `ansible-galaxy install -r requirements.yml`.
 
@@ -102,7 +102,9 @@ BSD
 Author Information
 ------------------
 
-Thanks to [nodesource](https://nodesource.com/) for the Nodejs packages repository and Ansible role.
+Thanks to [nodesource](https://nodesource.com/) for the Nodejs packages repository
+
+Thanks to [SimpliField](http://www.simplifield.com/) for the Ansible role.
 
 Thanks to [jdauphant](https://github.com/jdauphant/) for the Nginx role.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,8 +15,7 @@ galaxy_info:
   categories:
   - web
 dependencies:
-  - role: nodesource.node
-    nodejs_nodesource_pin_priority: "{{ ghost_nodejs_pin_priority }}"
+  - role: SimpliField.node
     when: ghost_nodejs_enabled
     become: yes
     tags: ghost_nodejs

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
-- src: nodesource.node
-  version: 39f338b
+- src: SimpliField.node
+  version: v1.0.7
 
 - src: jdauphant.nginx
   version: v2.7.1


### PR DESCRIPTION
I'm already using these changes to install nodejs 6.x and thought you may like them too.

Thanks for the role :)